### PR TITLE
Implement SubscribeForm fetch

### DIFF
--- a/components/SubscribeForm.tsx
+++ b/components/SubscribeForm.tsx
@@ -46,7 +46,16 @@ const SubscribeForm: FC<SubscribeFormProps> = ({ onSuccess }) => {
     e.preventDefault();
     try {
       await schema.validate(form);
-      // TODO: llamar a API
+      const res = await fetch('/api/subscribe', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(form),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => null);
+        throw new Error(data?.error || 'Error');
+      }
+      setError('');
       onSuccess();
     } catch (err: any) {
       setError(err.message);

--- a/components/__tests__/SubscribeForm.test.tsx
+++ b/components/__tests__/SubscribeForm.test.tsx
@@ -4,6 +4,10 @@ import SubscribeForm from '../SubscribeForm';
 
 test('envia datos validos', async () => {
   const user = userEvent.setup();
+  (global as any).fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({ ok: true }),
+  });
   const onSuccess = jest.fn();
   render(<SubscribeForm onSuccess={onSuccess} />);
   await user.type(screen.getByPlaceholderText('Nombre'), 'Test');
@@ -12,5 +16,9 @@ test('envia datos validos', async () => {
   await user.click(screen.getByLabelText('Frontend'));
   await user.click(screen.getByLabelText('Acepto recibir comunicaciones'));
   await user.click(screen.getByText('Suscribirse'));
+  expect(global.fetch).toHaveBeenCalledWith(
+    '/api/subscribe',
+    expect.objectContaining({ method: 'POST' })
+  );
   expect(onSuccess).toHaveBeenCalled();
 });


### PR DESCRIPTION
## Summary
- connect `SubscribeForm` to the `/api/subscribe` endpoint
- mock `fetch` in `SubscribeForm` tests

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687785d0df608330aad9afd02e4f0044