### PR TITLE
Improve article archive filtering

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -16,10 +16,31 @@ const features = [
 
 const archive: ArchiveItem[] = [
   {
-    id: 'edicion-1',
+    id: 't1',
+    type: 'tutorial',
+    date: '2025-06-11',
+    title: 'Moving Highlight Navigation Bar',
+    excerpt: 'Tutorial para resaltar elementos con la View Transition API.',
+    source: 'Smashing Magazine',
+    link: '#',
+  },
+  {
+    id: 'n1',
+    type: 'noticia',
     date: '2025-07-14',
-    title: 'Edición 1',
-    excerpt: 'Artículos destacados de Abril – Julio 2025. Incluye Node.js 24, ECMAScript 2025, Next.js 15.4 y más.',
+    title: 'Next.js 15.4',
+    excerpt: 'Enfoque en rendimiento y compatibilidad total con Turbopack.',
+    source: 'Blog Next.js',
+    link: '#',
+  },
+  {
+    id: 'r1',
+    type: 'recomendacion',
+    date: '2025-04-01',
+    title: 'Vercel CLI',
+    excerpt: 'Herramienta para desplegar proyectos con facilidad.',
+    source: 'Vercel',
+    link: '#',
   },
 ];
 

--- a/components/ArchiveList.tsx
+++ b/components/ArchiveList.tsx
@@ -1,53 +1,93 @@
-import Link from 'next/link';
-import { FC, useState } from 'react';
+'use client';
+import { FC, useEffect, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { motion } from 'framer-motion';
+import Card from './Card';
 
 export interface ArchiveItem {
   id: string;
+  type: 'tutorial' | 'noticia' | 'recomendacion';
   date: string;
   title: string;
   excerpt: string;
+  source: string;
+  link: string;
 }
 
 interface ArchiveListProps {
   items: ArchiveItem[];
 }
 
-/**
- * Lista de ediciones publicadas.
- */
+const itemAnim = {
+  hidden: { opacity: 0, y: 20 },
+  show: { opacity: 1, y: 0 },
+};
+
 const ArchiveList: FC<ArchiveListProps> = ({ items }) => {
-  const [year, setYear] = useState('');
-  const years = Array.from(new Set(items.map((i) => i.date.slice(0, 4))));
-  const filtered = year ? items.filter((i) => i.date.startsWith(year)) : items;
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const param = searchParams.get('type') || 'all';
+
+  const [type, setType] = useState(param);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => setType(param), [param]);
+
+  const types = Array.from(new Set(items.map((i) => i.type)));
+  const counts: Record<string, number> = {};
+  types.forEach((t) => {
+    counts[t] = items.filter((i) => i.type === t).length;
+  });
+
+  const filtered = type === 'all' ? items : items.filter((i) => i.type === type);
+
+  const handleChange = (value: string) => {
+    setLoading(true);
+    setType(value);
+    const params = new URLSearchParams(searchParams.toString());
+    if (value === 'all') params.delete('type');
+    else params.set('type', value);
+    router.replace('?' + params.toString(), { scroll: false });
+    setTimeout(() => setLoading(false), 300);
+  };
+
+  const capitalize = (s: string) => s.charAt(0).toUpperCase() + s.slice(1);
 
   return (
     <section className="py-10">
-      <h2 className="text-2xl font-bold mb-4">Archivo</h2>
-      {years.length > 1 && (
+      <h2 className="text-2xl font-bold mb-4">Artículos</h2>
+      <div className="mb-4">
+        <label htmlFor="type-select" className="sr-only">
+          Filtrar por tipo
+        </label>
         <select
-          aria-label="Filtrar por año"
-          className="mb-4 bg-gray-800 p-2"
-          value={year}
-          onChange={(e) => setYear(e.target.value)}
+          id="type-select"
+          aria-label="Filtrar por tipo"
+          className="bg-gray-800 p-2 rounded focus:outline-none focus:ring"
+          value={type}
+          onChange={(e) => handleChange(e.target.value)}
         >
-          <option value="">Todas</option>
-          {years.map((y) => (
-            <option key={y} value={y}>
-              {y}
+          <option value="all">Todos ({items.length})</option>
+          {types.map((t) => (
+            <option key={t} value={t}>
+              {capitalize(t)} ({counts[t]})
             </option>
           ))}
         </select>
-      )}
-      <ul className="space-y-4">
+      </div>
+      {loading && <p>Loading...</p>}
+      {!loading && filtered.length === 0 && <p>No hay artículos de este tipo</p>}
+      <ul className="grid gap-4" role="list">
         {filtered.map((it) => (
-          <li key={it.id}>
-            <Link href={`/newsletters/${it.id}`} className="underline">
-              {it.date} - {it.title}
-            </Link>
-            <p className="text-sm text-gray-400">
-              {it.excerpt.slice(0, 100)}
-            </p>
-          </li>
+          <motion.li
+            key={it.id}
+            variants={itemAnim}
+            initial="hidden"
+            whileInView="show"
+            viewport={{ once: true }}
+          >
+            <Card item={it} />
+          </motion.li>
         ))}
       </ul>
     </section>

--- a/components/Card.tsx
+++ b/components/Card.tsx
@@ -1,0 +1,24 @@
+'use client';
+import { FC } from 'react';
+import Link from 'next/link';
+import { ArchiveItem } from './ArchiveList';
+
+interface CardProps {
+  item: ArchiveItem;
+}
+
+const Card: FC<CardProps> = ({ item }) => (
+  <article className="p-4 bg-gray-800 border border-gray-700 rounded-lg shadow hover:shadow-pink-500/25 transition">
+    <h3 className="text-lg font-bold text-pink-400 mb-1">
+      <Link href={item.link} className="hover:underline">
+        {item.title}
+      </Link>
+    </h3>
+    <p className="text-sm text-gray-400 mb-2">
+      {item.date} &bull; {item.source}
+    </p>
+    <p className="text-gray-300 text-sm">{item.excerpt}</p>
+  </article>
+);
+
+export default Card;

--- a/components/__tests__/ArchiveList.test.tsx
+++ b/components/__tests__/ArchiveList.test.tsx
@@ -1,17 +1,44 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import ArchiveList from '../ArchiveList';
 
-test('muestra elementos de archivo y permite navegar', () => {
+const replace = jest.fn();
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ replace }),
+  useSearchParams: () => ({ get: () => null, toString: () => '' }),
+}));
+
+test('filtra elementos por tipo y actualiza la URL', () => {
   render(
     <ArchiveList
       items={[
-        { id: 'ed1', date: '2024-01-01', title: 'Ed1', excerpt: '...' },
-        { id: 'ed2', date: '2025-01-01', title: 'Ed2', excerpt: '...' },
+        {
+          id: '1',
+          type: 'tutorial',
+          date: '2024-01-01',
+          title: 'Tut',
+          excerpt: '...',
+          source: 'src',
+          link: '#',
+        },
+        {
+          id: '2',
+          type: 'noticia',
+          date: '2024-01-02',
+          title: 'Not',
+          excerpt: '...',
+          source: 'src',
+          link: '#',
+        },
       ]}
     />
   );
-  expect(screen.getByText(/Ed1/)).toBeInTheDocument();
-  fireEvent.change(screen.getByLabelText('Filtrar por año'), { target: { value: '2025' } });
-  expect(screen.queryByText(/Ed1/)).not.toBeInTheDocument();
-  expect(screen.getByText(/Ed2/)).toBeInTheDocument();
+  expect(screen.getByText(/Tut/)).toBeInTheDocument();
+  expect(screen.getByText('Tutorial (1)')).toBeInTheDocument();
+  expect(screen.getAllByRole('listitem').length).toBe(2);
+  fireEvent.change(screen.getByLabelText('Filtrar por tipo'), {
+    target: { value: 'noticia' },
+  });
+  expect(screen.queryByText(/Tut/)).not.toBeInTheDocument();
+  expect(screen.getByText(/Not/)).toBeInTheDocument();
+  expect(replace).toHaveBeenCalledWith('?type=noticia', { scroll: false });
 });


### PR DESCRIPTION
## Summary
- add a simple `Card` component for article entries
- refactor `ArchiveList` to support filtering by type, dynamic counts and query parameter syncing
- update homepage demo data to use the new item shape
- revise tests for new filter logic

## Testing
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68778c7a23fc8330a1ac0eea04403145