### PR TITLE
Add basic Next SEO config

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,13 +1,16 @@
 import './globals.css';
 import { ReactNode } from 'react';
 // import { Analytics } from '@vercel/analytics/react';
-// import { DefaultSeo } from 'next-seo';
+import { DefaultSeo } from 'next-seo';
+import SEO, { metadata } from '../next-seo.config';
+
+export { metadata };
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="es">
       <body className="min-h-screen bg-gray-900 text-gray-200">
-        {/* <DefaultSeo title="NeonBytes" description="Newsletter tech" /> */}
+        <DefaultSeo {...SEO} />
         <header className="p-4 text-center text-2xl font-bold text-pink-400">
           NeonBytes
         </header>

--- a/app/newsletters/[edition]/page.tsx
+++ b/app/newsletters/[edition]/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { useEffect, useState } from 'react';
 import NewsletterPage from '../../../components/NewsletterPage';
+import { NextSeo } from 'next-seo';
 
 // Define meta information directly since we can't use fs in client components
 const editionMeta = {
@@ -56,8 +57,11 @@ export default function Page({ params }: { params: { edition: string } }) {
   }
 
   return (
-    <NewsletterPage meta={meta}>
-      <Content />
-    </NewsletterPage>
+    <>
+      <NextSeo title={meta.title} description={meta.excerpt} />
+      <NewsletterPage meta={meta}>
+        <Content />
+      </NewsletterPage>
+    </>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useRef, useState } from 'react';
+import { NextSeo } from 'next-seo';
 import Hero from '../components/Hero';
 import Features from '../components/Features';
 import ArchiveList, { ArchiveItem } from '../components/ArchiveList';
@@ -118,15 +119,22 @@ export default function Home() {
   };
 
   return (
-    <main>
-      <Hero onSubscribeClick={() => formRef.current?.scrollIntoView()} />
-      <Features items={features} onFilterChange={handleFilterChange} />
-      <ArchiveList items={archive} selectedFilter={selectedFilter} onFilterChange={setSelectedFilter} />
-      <About text="Proyecto dedicado a compartir novedades del mundo tech." />
-      <div ref={formRef}>
-        <SubscribeForm onSuccess={() => null} />
-      </div>
-      <Footer year={new Date().getFullYear()} />
-    </main>
+    <>
+      <NextSeo title="Inicio" />
+      <main>
+        <Hero onSubscribeClick={() => formRef.current?.scrollIntoView()} />
+        <Features items={features} onFilterChange={handleFilterChange} />
+        <ArchiveList
+          items={archive}
+          selectedFilter={selectedFilter}
+          onFilterChange={setSelectedFilter}
+        />
+        <About text="Proyecto dedicado a compartir novedades del mundo tech." />
+        <div ref={formRef}>
+          <SubscribeForm onSuccess={() => null} />
+        </div>
+        <Footer year={new Date().getFullYear()} />
+      </main>
+    </>
   );
 }

--- a/next-seo.config.ts
+++ b/next-seo.config.ts
@@ -1,0 +1,17 @@
+import type { DefaultSeoProps } from 'next-seo';
+import type { Metadata } from 'next';
+
+const title = 'NeonBytes';
+const description = 'La newsletter tecnológica que te conecta con las últimas tendencias';
+
+export const metadata: Metadata = {
+  title,
+  description,
+};
+
+const config: DefaultSeoProps = {
+  title,
+  description,
+};
+
+export default config;


### PR DESCRIPTION
## Summary
- setup `next-seo` defaults
- enable `<DefaultSeo>` in the layout
- export `metadata` for Next.js
- add `<NextSeo>` to home page and newsletter editions

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878cf0226848330811aa3c06ed0e59c