### PR TITLE
Enable strict mode for TypeScript

### DIFF
--- a/app/newsletters/[edition]/page.tsx
+++ b/app/newsletters/[edition]/page.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import NewsletterPage from '../../../components/NewsletterPage';
 
 // Define meta information directly since we can't use fs in client components
@@ -14,7 +14,7 @@ const editionMeta = {
 };
 
 export default function Page({ params }: { params: { edition: string } }) {
-  const [Content, setContent] = useState(null);
+  const [Content, setContent] = useState<React.ComponentType | null>(null);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {

--- a/components/__tests__/ArchiveList.test.tsx
+++ b/components/__tests__/ArchiveList.test.tsx
@@ -30,6 +30,8 @@ test('filtra elementos por tipo y actualiza la URL', () => {
           link: '#',
         },
       ]}
+      selectedFilter="all"
+      onFilterChange={() => {}}
     />
   );
   expect(screen.getByText(/Tut/)).toBeInTheDocument();

--- a/components/__tests__/Features.test.tsx
+++ b/components/__tests__/Features.test.tsx
@@ -4,7 +4,8 @@ import Features from '../Features';
 test('muestra titulos de features', () => {
   render(
     <Features
-      items={[{ icon: <>x</>, title: 't1', text: 'desc' }]}
+      items={[{ icon: <>x</>, title: 't1', text: 'desc', type: 'test' }]}
+      onFilterChange={() => {}}
     />
   );
   expect(screen.getByText('t1')).toBeInTheDocument();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
     ],
     "allowJs": true,
     "skipLibCheck": true,
-    "strict": false,
+    "strict": true,
     "forceConsistentCasingInFileNames": true,
     "noEmit": true,
     "esModuleInterop": true,


### PR DESCRIPTION
## Summary
- enable strict mode in tsconfig
- fix component state typing
- update tests to satisfy new prop requirements

## Testing
- `npm test` *(fails: jest not found)*
- `npx tsc --noEmit` *(fails: missing module declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6878cf0e80ec8330bfa1cf14c1c7b43d