### PR TITLE
Add simple rate limiter

### DIFF
--- a/app/api/subscribe/route.ts
+++ b/app/api/subscribe/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { addSubscriber, Subscriber } from '../../../lib/subscribers';
+import { rateLimit } from '../../../lib/rateLimit';
 import { z } from 'zod';
 import nodemailer from 'nodemailer';
 
@@ -44,6 +45,15 @@ const schema = z.object({
  * Endpoint para registrar un nuevo suscriptor.
  */
 export async function POST(req: NextRequest) {
+  const ip =
+    req.headers.get('x-forwarded-for')?.split(',')[0].trim() || 'unknown';
+  if (!rateLimit(ip)) {
+    return NextResponse.json(
+      { error: 'Too many requests' },
+      { status: 429 }
+    );
+  }
+
   const data = await req.json();
   const result = schema.safeParse(data);
   if (!result.success) {

--- a/lib/rateLimit.ts
+++ b/lib/rateLimit.ts
@@ -1,0 +1,31 @@
+export type RateLimitOptions = {
+  limit?: number;
+  windowMs?: number;
+};
+
+// Store request counts per IP
+const requests = new Map<string, { count: number; timer: NodeJS.Timeout }>();
+
+/**
+ * Checks if the IP is within the allowed request limit.
+ * Returns true if the request should be allowed, false otherwise.
+ */
+export function rateLimit(ip: string, options: RateLimitOptions = {}): boolean {
+  const limit = options.limit ?? 5;
+  const windowMs = options.windowMs ?? 60_000; // 1 minute
+
+  const entry = requests.get(ip);
+  if (!entry) {
+    const timer = setTimeout(() => {
+      requests.delete(ip);
+    }, windowMs);
+    requests.set(ip, { count: 1, timer });
+    return true;
+  }
+
+  entry.count += 1;
+  if (entry.count > limit) {
+    return false;
+  }
+  return true;
+}


### PR DESCRIPTION
## Summary
- add lightweight in-memory rate limiter
- return `429` if the request count per IP exceeds the limit in `/api/subscribe`

## Testing
- `pnpm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878cf1e05fc8330bf9298c4625ebda5