### PR TITLE
Add example env and update docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+# Configuración de email
+EMAIL_USER=your-email@example.com
+EMAIL_PASS=your-app-password
+
+# Nota: Para que funcione en producción, necesitarás:
+# 1. Crear una cuenta de Gmail para la newsletter
+# 2. Habilitar la autenticación de 2 factores
+# 3. Generar una "App Password" específica para esta aplicación
+# 4. Configurar estas variables en Vercel con los valores reales

--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@
 git clone https://github.com/YerayAR/neon-bytes.git
 cd neon-bytes
 
+# Copiar variables de entorno de ejemplo
+cp .env.example .env.local
+
 # Instalar dependencias
 pnpm install
 # o


### PR DESCRIPTION
## Summary
- add `.env.example` with placeholders for the email credentials
- mention example env file in installation instructions

## Testing
- `pnpm install` *(fails: registry access blocked)*
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878cf27dd148330a8937cc6cc34dd98