### PR TITLE
Add new neon component and edition 2

### DIFF
--- a/app/newsletters/[edition]/page.tsx
+++ b/app/newsletters/[edition]/page.tsx
@@ -18,6 +18,13 @@ const editionMeta: Record<string, EditionMeta> = {
     date: '2025-07-14',
     excerpt: 'Artículos destacados de Abril – Julio 2025',
     authors: 'Equipo NeonBytes'
+  },
+  'edicion-2': {
+    id: 'edicion-2',
+    title: 'Edición 2',
+    date: '2025-07-17',
+    excerpt: 'Artículos destacados Abril–Julio 2025 (segunda edición)',
+    authors: 'Equipo NeonBytes'
   }
 };
 

--- a/components/ArchiveList.tsx
+++ b/components/ArchiveList.tsx
@@ -50,7 +50,7 @@ const ArchiveList: FC<ArchiveListProps> = ({ items, selectedFilter, onFilterChan
       <FloatingBubbles count={12} colors={['bg-yellow-500', 'bg-orange-500', 'bg-yellow-400', 'bg-orange-400']} />
       
       <div className="text-center mb-12 relative z-10">
-        <h2 className="text-4xl font-bold text-white mb-4 animate-fadeInUp">Edición Uno</h2>
+        <h2 className="text-4xl font-bold text-white mb-4 animate-fadeInUp">Edición Dos</h2>
         <p className="text-gray-400 text-lg max-w-2xl mx-auto animate-fadeInUp" style={{animationDelay: '0.2s'}}>
           Artículos destacados de abril a julio 2025 - Las últimas novedades del mundo tech
         </p>

--- a/components/NeonCentelleante.module.css
+++ b/components/NeonCentelleante.module.css
@@ -1,0 +1,22 @@
+@keyframes neonBlink {
+  0%, 100% {
+    opacity: 1;
+    text-shadow: 0 0 calc(var(--glow-intensity,1) * 4px) #ff00cc,
+                 0 0 calc(var(--glow-intensity,1) * 8px) #ff00cc,
+                 0 0 calc(var(--glow-intensity,1) * 12px) #ff00cc;
+  }
+  50% {
+    opacity: 0.5;
+    text-shadow: 0 0 calc(var(--glow-intensity,1) * 2px) #ff00cc,
+                 0 0 calc(var(--glow-intensity,1) * 4px) #ff00cc;
+  }
+}
+
+.blink {
+  animation-name: neonBlink;
+  animation-iteration-count: infinite;
+  animation-timing-function: ease-in-out;
+  color: #fff;
+  font-weight: 700;
+  text-transform: uppercase;
+}

--- a/components/NeonCentelleante.tsx
+++ b/components/NeonCentelleante.tsx
@@ -1,0 +1,27 @@
+'use client';
+import { FC } from 'react';
+import { motion } from 'framer-motion';
+import styles from './NeonCentelleante.module.css';
+
+interface NeonCentelleanteProps {
+  /** Duración de cada ciclo de parpadeo en milisegundos */
+  duration?: number;
+  /** Intensidad del resplandor (factor aplicado a la sombra) */
+  intensity?: number;
+}
+
+/**
+ * Muestra un texto con efecto de neón parpadeante.
+ */
+const NeonCentelleante: FC<NeonCentelleanteProps> = ({ duration = 1200, intensity = 1 }) => (
+  <motion.span
+    aria-label="mensaje neón"
+    className={`${styles.blink} text-pink-400 drop-shadow-lg`}
+    style={{ animationDuration: `${duration}ms`, '--glow-intensity': intensity } as React.CSSProperties}
+    role="status"
+  >
+    este semestre newsletter extra
+  </motion.span>
+);
+
+export default NeonCentelleante;

--- a/components/__tests__/NeonCentelleante.test.tsx
+++ b/components/__tests__/NeonCentelleante.test.tsx
@@ -1,0 +1,7 @@
+import { render, screen } from '@testing-library/react';
+import NeonCentelleante from '../NeonCentelleante';
+
+test('muestra texto de neon', () => {
+  render(<NeonCentelleante duration={500} intensity={1.2} />);
+  expect(screen.getByText('este semestre newsletter extra')).toBeInTheDocument();
+});

--- a/lib/__tests__/newsletters.test.ts
+++ b/lib/__tests__/newsletters.test.ts
@@ -1,6 +1,11 @@
 import { getEditionMeta } from '../newsletters';
 
-test('carga frontmatter de newsletter', () => {
+test('carga frontmatter de newsletter existente', () => {
   const meta = getEditionMeta('edicion-1');
   expect(meta.title).toBe('Edición 1');
+});
+
+test('carga frontmatter de nueva edición', () => {
+  const meta = getEditionMeta('edicion-2');
+  expect(meta.title).toBe('Edición 2');
 });

--- a/newsletters/edicion-2.mdx
+++ b/newsletters/edicion-2.mdx
@@ -1,0 +1,41 @@
+---
+id: edicion-2
+title: "Edición 2"
+date: "2025-07-17"
+excerpt: "Artículos destacados Abril–Julio 2025 (segunda edición)"
+authors: ["Equipo NeonBytes"]
+---
+
+'use client'
+
+import { useState } from 'react'
+import ArchiveList, { ArchiveItem } from '../components/ArchiveList'
+import NeonCentelleante from '../components/NeonCentelleante'
+
+const articles: ArchiveItem[] = [
+  { id: 'n1', type: 'noticia', date: '2025-05-10', title: 'OpenAI Releases GPT-5', excerpt: 'Nueva versión del modelo con mejor razonamiento y compresión.', source: 'OpenAI Blog', link: 'https://openai.com/blog/gpt-5' },
+  { id: 'n2', type: 'noticia', date: '2025-06-01', title: 'Chrome 120 Adds WebGPU 2', excerpt: 'El navegador habilita la segunda generación de WebGPU para gráficos avanzados.', source: 'Chromium Blog', link: 'https://blog.chromium.org' },
+  { id: 'n3', type: 'noticia', date: '2025-07-02', title: 'React 19 Beta Introduces Offscreen', excerpt: 'Nueva API Offscreen para mejorar rendimiento en aplicaciones pesadas.', source: 'React Blog', link: 'https://react.dev/blog' },
+  { id: 'n4', type: 'noticia', date: '2025-04-22', title: 'WebAssembly GC Standard Completed', excerpt: 'El comité aprueba el soporte de garbage collection en WebAssembly.', source: 'W3C', link: 'https://www.w3.org' },
+  { id: 'n5', type: 'noticia', date: '2025-06-20', title: 'AWS Launches Quantum Cloud Service', excerpt: 'Amazon presenta un servicio de computación cuántica bajo demanda.', source: 'AWS News', link: 'https://aws.amazon.com/blogs/aws' },
+  { id: 'n6', type: 'noticia', date: '2025-07-05', title: 'Rust 1.80 Gains Async FFI', excerpt: 'La versión 1.80 incorpora compatibilidad async en FFI.', source: 'Rust Blog', link: 'https://blog.rust-lang.org' },
+  { id: 't1', type: 'tutorial', date: '2025-05-15', title: 'Building Real-time Apps with Bun', excerpt: 'Tutorial para crear backends ultrarrápidos usando Bun.', source: 'Bun Docs', link: 'https://bun.sh/docs' },
+  { id: 't2', type: 'tutorial', date: '2025-06-28', title: 'Server Actions in Next.js 15', excerpt: 'Guía práctica de las nuevas Server Actions de Next.js.', source: 'Vercel', link: 'https://nextjs.org/docs' },
+  { id: 't3', type: 'tutorial', date: '2025-07-12', title: 'Mastering Tailwind CSS 4.0', excerpt: 'Consejos para aprovechar las novedades de Tailwind 4.0.', source: 'Tailwind Labs', link: 'https://tailwindcss.com/blog' },
+  { id: 'r1', type: 'recomendacion', date: '2025-04-30', title: 'GitHub CLI 3.0: The Complete Toolkit', excerpt: 'Gestiona tus repositorios desde la terminal con nuevas capacidades.', source: 'GitHub', link: 'https://github.com/cli/cli/releases' }
+]
+
+function Articles() {
+  const [filter, setFilter] = useState('all')
+  return <ArchiveList items={articles} selectedFilter={filter} onFilterChange={setFilter} />
+}
+
+<NeonCentelleante duration={1500} intensity={1.3} />
+
+## Artículos destacados
+
+<Articles />
+
+## Cierre
+
+Gracias por leer esta segunda edición de **NeonBytes**.


### PR DESCRIPTION
## Summary
- add `NeonCentelleante` blinking text component
- rename heading in `ArchiveList` and register `edicion-2`
- include new newsletter content for Edición 2 with interactive filter
- extend newsletter tests to cover edition 2
- add unit test for new component

## Testing
- `pnpm lint` *(fails: next not found)*
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878dc442ef48330bfa3a79dae0a8270